### PR TITLE
feat: introduce fetchWithAuth for authenticated requests

### DIFF
--- a/lib/fetchWithAuth.ts
+++ b/lib/fetchWithAuth.ts
@@ -1,0 +1,23 @@
+// src/lib/fetchWithAuth.ts
+export async function fetchWithAuth(
+  url: string,
+  options: RequestInit = {}
+) {
+  const token = localStorage.getItem("access_token");
+
+  const res = await fetch(url, {
+    ...options,
+    headers: {
+      ...options.headers,
+      Authorization: token ? `Bearer ${token}` : "",
+    },
+  });
+
+  if (res.status === 401) {
+    localStorage.removeItem("access_token");
+    window.location.href = "/login";
+    throw new Error("인증 만료");
+  }
+
+  return res;
+}

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -1,19 +1,18 @@
 // src/apis/user.ts
-import { getAccessToken } from "@/lib/auth";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
 export async function updatePrivacyConsent(version: number) {
-  const token = localStorage.getItem("access_token");
-
-  const res = await fetch(`${API_BASE_URL}/users/consent/privacy`, {
-    method: "PATCH",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify({ version }),
-  });
+  const res = await fetchWithAuth(
+    `${API_BASE_URL}/users/consent/privacy`,
+    {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ version }),
+    }
+  );
 
   if (!res.ok) {
     const error = await res.json();
@@ -23,26 +22,20 @@ export async function updatePrivacyConsent(version: number) {
   return res.json(); // { message, user }
 }
 
+import { fetchWithAuth } from "@/lib/fetchWithAuth";
+
 export async function fetchMe() {
-  const token = getAccessToken();
+  try {
+    const res = await fetchWithAuth(`${API_BASE_URL}/users/me`);
 
-  if (!token) return null;
+    if (!res.ok) return null;
 
-  const res = await fetch(`${API_BASE_URL}/users/me`, {
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-  });
+    const data = await res.json();
 
-  if (res.ok) {
-    console.log("토큰 만료 혹은 인증 실패");
+    return data.user ?? null;
+
+  } catch {
+    // fetchWithAuth에서 401이면 이미 처리됨
     return null;
   }
-  
-  const data = await res.json();
-
-  if (!data.ok) return null;
-
-  return data.user;
 }

--- a/src/app/checklist/lifestyle-test/page.tsx
+++ b/src/app/checklist/lifestyle-test/page.tsx
@@ -4,6 +4,8 @@ import React from 'react';
 import { StepTabs } from '../../../components/survey/StepTabs';
 import { CheckboxGroup, TextAreaWithPreview, TagInput } from '../../../components/survey/QuestionControls';
 
+import { getAccessToken } from '@/lib/auth';
+
 const STEPS = [
     '기본정보 4문항',
     '생활루틴 2문항',
@@ -331,7 +333,7 @@ export default function LifestyleTestPage() {
             const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL;
             if (!apiBase) throw new Error('NEXT_PUBLIC_API_BASE_URL 환경변수가 없어요.');
 
-            const token = localStorage.getItem('accessToken');
+            const token = getAccessToken();
             if (!token) throw new Error('로그인이 필요해요(토큰 없음).');
 
             const { mbti1, mbti2, mbti3, mbti4 } = splitMbti(basicInfo.mbti);
@@ -386,6 +388,7 @@ export default function LifestyleTestPage() {
 
             if (!res.ok) {
                 const text = await res.text();
+                console.error(res.status, text);
                 throw new Error(`서버 오류: ${res.status} ${text}`);
             }
 


### PR DESCRIPTION
인증이 필요한 모든 api 요청에서 쓸 수 있도록 fetchwithAuth추가. 이 함수 쓰면 서버에서 토큰 만료로 401 보낼 시 로컬 토큰 자동으로 정리해줌.