### PR TITLE
fix: 체크리스트 기반 매칭 진입 흐름 복구

### DIFF
--- a/app/(main)/_components/MainHeroSection.tsx
+++ b/app/(main)/_components/MainHeroSection.tsx
@@ -9,15 +9,9 @@ export default function MainHeroSection() {
   const { hasChecklist, loading } = useChecklistStatus();
 
   const handleClick = () => {
-    if (loading) return;
+    if (loading || hasChecklist === null) return;
 
-    if (hasChecklist) {
-      //체크리스트 완료 → 매칭 페이지
-      router.push("/matching");
-    } else {
-      //미완료 → 체크리스트 페이지
-      router.push("/checklist");
-    }
+    router.push(hasChecklist ? "/matching" : "/checklist");
   };
   return (
     <div className="flex flex-col items-center justify-center gap-1 py-20 min-h-[1100px]">

--- a/app/(matching)/matching/page.tsx
+++ b/app/(matching)/matching/page.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-
 import { useMatching } from "@/hooks/matching/useMatching";
 
 import MatchProfileCard from "./_components/MatchProfileCard";
@@ -10,15 +8,10 @@ import NoMatchingResult from "./_components/NoMatchingResult";
 import Button from "@/components/ui/Button";
 
 export default function MatchingPage() {
-  const router = useRouter();
 
-  const { data, loading, error, rematch, setData, blockedByChecklist } = useMatching();
+  const { data, loading, error, rematch, setData } = useMatching();
 
-  // 체크리스트가 없으면 체크리스트 페이지로 리다이렉트
-  if (blockedByChecklist) {
-    router.replace("/checklist");
-    return null;
-  }
+
 
   if (loading) {
     return <div>매칭 중...</div>;
@@ -31,7 +24,6 @@ export default function MatchingPage() {
   if (!data) {
     return <div>매칭 데이터를 불러오지 못했습니다.</div>;
   }
-
 
   const handleLikeChange = (userId: string, liked: boolean) => {
     setData((prev) => {

--- a/lib/fetchWithAuth.ts
+++ b/lib/fetchWithAuth.ts
@@ -1,16 +1,22 @@
 // src/lib/fetchWithAuth.ts
-export async function fetchWithAuth(
-  url: string,
-  options: RequestInit = {}
-) {
+export async function fetchWithAuth(url: string, options: RequestInit = {}) {
   const token = localStorage.getItem("access_token");
+
+  const headers: Record<string, string> = {
+    ...(options.headers as Record<string, string>),
+  };
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
 
   const res = await fetch(url, {
     ...options,
-    headers: {
-      ...options.headers,
-      Authorization: token ? `Bearer ${token}` : "",
-    },
+
+    // fetch 레벨 캐시 차단
+    cache: "no-store",
+
+    headers,
   });
 
   if (res.status === 401) {

--- a/src/apis/checklist.ts
+++ b/src/apis/checklist.ts
@@ -31,6 +31,8 @@ export async function fetchChecklistStatus(): Promise<MySurveyResponse> {
       method: "GET",
     }
   );
+ 
+
 
   if (!res.ok) {
     throw new Error("체크리스트 조회 실패");

--- a/src/hooks/checklist/useChecklistStatus.ts
+++ b/src/hooks/checklist/useChecklistStatus.ts
@@ -11,23 +11,28 @@ export function useChecklistStatus() {
     let mounted = true;
 
     fetchChecklistStatus()
-    .then((res) => {
-        if(!mounted) return;
+      .then((res) => {
+        if (!mounted) return;
+        console.log("체크리스트 여부 API", res);
+        console.log(
+          "checklist hook env",
+          typeof window === "undefined" ? "SERVER" : "CLIENT"
+        );
         setHasChecklist(res.exists);
-    })
-    .catch((err) => {
-        setError(err);
+      })
+      .catch((err) => {
+        console.error("checklist api error", err);
+        setError(String(err));
         setHasChecklist(false);
-    })
-    .finally(() => {
+      })
+      .finally(() => {
         if (!mounted) return;
         setLoading(false);
-    });
+      });
 
     return () => {
-        mounted = false;
+      mounted = false;
     };
-
   }, []);
 
   return { hasChecklist, loading, error };

--- a/src/hooks/matching/useMatching.ts
+++ b/src/hooks/matching/useMatching.ts
@@ -12,7 +12,6 @@ import { useEffect, useState } from "react";
 
 // api 임포트
 import { fetchMatchingStatus, fetchMatchingResult } from "@/apis/matching";
-import { fetchChecklistStatus } from "@/apis/checklist";
 
 // 타입 임포트
 import type {
@@ -22,8 +21,6 @@ import type {
 } from "@/types/matching";
 
 export function useMatching() {
-  const [blockedByChecklist, setBlockedByChecklist] = useState(false);
-
   const [data, setData] = useState<MatchingResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -34,16 +31,7 @@ export function useMatching() {
     setError(null);
 
     try {
-      // 체크리스트 작성 여부 확인
-      const checklistRes = await fetchChecklistStatus();
-
-      // 체크리스트가 없으면 매칭 로직 실행하지 않음
-      if (!checklistRes.exists) {
-         setBlockedByChecklist(true);
-        // data를 null로 유지 (페이지 쪽에서 checklist로 보내거나 처리)
-        return;
-      }
-
+  
       // 기존 매칭 결과 조회
       const status: MatchingStatusResponse = await fetchMatchingStatus();
 
@@ -95,5 +83,5 @@ export function useMatching() {
     runInitialMatchingFlow();
   }, []);
 
-  return { data, loading, error, rematch, setData, blockedByChecklist };
+  return { data, loading, error, rematch, setData };
 }


### PR DESCRIPTION
- 메인에서 체크리스트 분기 로직 정상화
- 매칭 훅의 중복 체크리스트 검사 제거
- checklist API 응답 body 중복 읽기 버그 수정
- 매칭 오케스트레이션 로직 안정화